### PR TITLE
Add overwrite protocol step

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -74,6 +74,12 @@ NETWORK=webproxy
 $ docker-compose up -d
 ```
 
+4. Overwrite protocol to https
+
+```bash
+$ docker exec --user www-data cloud-app php occ config:system:set overwriteprotocol --value="https"
+```
+
 > This container must be in a network connected to your webproxy containers or use the same network of the webproxy.
 
 > Please keep in mind that when starting for the first time it may take a few moments (even a couple minutes) to get your Let's Encrypt certificates generated.


### PR DESCRIPTION
Sets the `overwriteprotocol` value to https. Otherwise, [granting access](https://github.com/nextcloud/android/issues/4786) on the mobile app will not work. 

I tried adding `NEXTCLOUD_OVERWRITEPROTOCOL: https` as an environment variable in `.env` but it did not appear to fix the issue.